### PR TITLE
Commented out line with undefined variable

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -135,7 +135,7 @@ class pocketNCAdapter(object):
 
 
                 self.adapter.begin_gather()
-                self.power.set_value(pwr)
+                #self.power.set_value(pwr)  #Not sure why this is not defined...
                 self.adapter.complete_gather()
                 
                 self.adapter.begin_gather()


### PR DESCRIPTION
This variable appears to be undefined at this point in the code.  It causes the adapter to fail silently.  The error is caught by the Try statement and just causes all of the outputs to be "UNAVAILABLE".